### PR TITLE
Use :microseconds instead of :micro_seconds

### DIFF
--- a/lib/prometheus/ecto_instrumenter.ex
+++ b/lib/prometheus/ecto_instrumenter.ex
@@ -213,7 +213,7 @@ defmodule Prometheus.EctoInstrumenter do
       end
 
       defp microseconds_time(time) do
-        System.convert_time_unit(time, :native, :micro_seconds)
+        System.convert_time_unit(time, :native, :microseconds)
       end
     end
   end


### PR DESCRIPTION
In later versions of Erlang, `:micro_seconds` is a deprecated time unit.  This seems to be the source of some dialyzer warnings in projects that use `Prometheus.EctoInstrumenter`.

Closes issue #7