### PR TITLE
Add option to count total Ecto queries

### DIFF
--- a/test/prometheus_ecto_test.exs
+++ b/test/prometheus_ecto_test.exs
@@ -23,6 +23,12 @@ defmodule PrometheusEctoTest do
     result = TestRepo.query!("SELECT 1")
     assert result.rows == [[1]]
 
+    assert_raise Prometheus.UnknownMetricError, fn ->
+      Counter.value(
+        name: :ecto_queries_total
+      )
+    end
+
     assert {buckets, sum} =
              Histogram.value(
                name: :ecto_query_duration_microseconds,
@@ -115,6 +121,13 @@ defmodule PrometheusEctoTest do
     assert 3 = length(buckets)
     assert sum < 1
     assert 1 = Enum.reduce(buckets, fn x, acc -> x + acc end)
+
+    assert 1 ==
+             Counter.value(
+               name: :ecto_queries_total,
+               registry: :qwe,
+               labels: ["custom_label"]
+             )
 
     assert {buckets, sum} =
              Histogram.value(

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -16,6 +16,7 @@ Application.put_env(
   labels: [:custom_label],
   registry: :qwe,
   stages: [:queue, :query],
+  counter: true,
   query_duration_buckets: [100, 200],
   duration_unit: :seconds
 )


### PR DESCRIPTION
It's disabled by default but can be enabled by setting `counter: true`
in an instrumenter configuration. The counter name is `ecto_queries_total`.