### PR TITLE
Ecto 3.1 / Telemetry 0.4.0 Updates

### DIFF
--- a/test/prometheus_ecto_test.exs
+++ b/test/prometheus_ecto_test.exs
@@ -13,7 +13,50 @@ defmodule PrometheusEctoTest do
     TestEctoInstrumenterWithConfig.setup()
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(TestRepo)
   end
+
   use Prometheus.Metric
+
+  describe "handle_event/4" do
+    test "Defaults decode_time, query_time, queue_time to 0 when not present" do
+      metadata =
+        TestEctoInstrumenter.append_latency_to_metadata(
+          %{total_time: 2_443_000},
+          %{
+            params: [],
+            query: "",
+            repo: TestRepo,
+            result: {:ok, %{}},
+            source: nil,
+            type: :ecto_sql_query
+          }
+        )
+
+      assert metadata.decode_time == 0
+      assert metadata.query_time == 0
+      assert metadata.queue_time == 0
+      assert metadata.total_time == 2_443_000
+    end
+
+    test "Defaults decode_time, query_time and queue_time to 0 when they are nil" do
+      metadata =
+        TestEctoInstrumenter.append_latency_to_metadata(
+          %{queue_time: nil, query_time: nil, decode_time: nil, total_time: 0},
+          %{
+            params: [],
+            query: "",
+            repo: TestRepo,
+            result: {:ok, %{}},
+            source: nil,
+            type: :ecto_sql_query
+          }
+        )
+
+      assert metadata.decode_time == 0
+      assert metadata.query_time == 0
+      assert metadata.queue_time == 0
+      assert metadata.total_time == 0
+    end
+  end
 
   test "the truth" do
     assert 1 + 1 == 2
@@ -24,9 +67,7 @@ defmodule PrometheusEctoTest do
     assert result.rows == [[1]]
 
     assert_raise Prometheus.UnknownMetricError, fn ->
-      Counter.value(
-        name: :ecto_queries_total
-      )
+      Counter.value(name: :ecto_queries_total)
     end
 
     assert {buckets, sum} =


### PR DESCRIPTION
Separated the default value append into its own method to test it better. Added two test cases for append_latency_to_metadata/4 that test their inclusion into metadata when: 1) they're not present or 2) they are set to nil. This is based on feedback from @chulkilee

@deadtrickster you mentioned ecto 3 test in my last PR. Since the setup is so different I can't think of a way to setup the instrumenter to work with both ecto 2 and 3. 