### PR TITLE
Fix for double time conversion

### DIFF
--- a/lib/prometheus/ecto_instrumenter.ex
+++ b/lib/prometheus/ecto_instrumenter.ex
@@ -228,7 +228,7 @@ defmodule Prometheus.EctoInstrumenter do
                       name: unquote(stage_metric_name(stage, duration_unit)),
                       labels: labels
                     ],
-                    microseconds_time(value)
+                    value
                   )
                 end
               end
@@ -267,10 +267,6 @@ defmodule Prometheus.EctoInstrumenter do
         else
           value
         end
-      end
-
-      defp microseconds_time(time) do
-        System.convert_time_unit(time, :native, :microsecond)
       end
     end
   end


### PR DESCRIPTION
Do not convert time because of https://github.com/deadtrickster/prometheus.erl/issues/106.

Prometheus.erl will convert from `native` time to the time unit derived by the metric name automatically, causing double conversion.